### PR TITLE
feat: enable efficiency day creation with neon transactions

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -57,6 +57,7 @@ functions:
   - ${file(./sls/functions/clients.yml)}
   - ${file(./sls/functions/contracts.yml)}
   - ${file(./sls/functions/rigs.yml)}
+  - ${file(./sls/functions/efficiency.yml)}
 
 resources:
   - ${file(./sls/resources/UserPool.yml)}

--- a/sls/functions/efficiency.yml
+++ b/sls/functions/efficiency.yml
@@ -1,0 +1,8 @@
+createEfficiencyDay:
+  handler: src/main/functions/efficiency/createEfficiencyDay.handler
+  events:
+    - httpApi:
+        method: POST
+        path: /efficiency/days
+        authorizer:
+          name: CognitoAuthorizer

--- a/src/application/controllers/efficiency/CreateEfficiencyDayController.ts
+++ b/src/application/controllers/efficiency/CreateEfficiencyDayController.ts
@@ -1,0 +1,60 @@
+import { Controller } from "@application/contracts/Controller";
+import { EfficiencyDay } from "@application/entities/EfficiencyDay";
+import { CreateEfficiencyDayUseCase } from "@application/useCases/efficiency/CreateEfficiencyDayUseCase";
+import { Injectable } from "@kernel/decorators/Injectable";
+import { Schema } from "@kernel/decorators/Schema";
+import {
+  CreateEfficiencyDayBody,
+  createEfficiencyDaySchema,
+} from "./schemas/createEfficiencyDaySchema";
+
+@Injectable()
+@Schema(createEfficiencyDaySchema)
+export class CreateEfficiencyDayController extends Controller<
+  "private",
+  CreateEfficiencyDayController.Response
+> {
+  constructor(
+    private readonly createEfficiencyDayUseCase: CreateEfficiencyDayUseCase
+  ) {
+    super();
+  }
+
+  protected override async handle({
+    body,
+  }: Controller.Request<"private", CreateEfficiencyDayBody>): Promise<
+    Controller.Response<CreateEfficiencyDayController.Response>
+  > {
+    const confirmedAt =
+      body.confirmedAt === undefined
+        ? undefined
+        : body.confirmedAt === null
+          ? null
+          : body.confirmedAt;
+
+    const confirmedByUserId =
+      body.confirmedByUserId === undefined
+        ? undefined
+        : body.confirmedByUserId === null
+          ? null
+          : body.confirmedByUserId;
+
+    const efficiencyDay = await this.createEfficiencyDayUseCase.execute({
+      rigId: body.rigId,
+      localDate: body.localDate,
+      status: body.status,
+      totals: body.totals ?? null,
+      confirmedAt,
+      confirmedByUserId,
+    });
+
+    return {
+      statusCode: 201,
+      body: efficiencyDay,
+    };
+  }
+}
+
+export namespace CreateEfficiencyDayController {
+  export type Response = EfficiencyDay;
+}

--- a/src/application/controllers/efficiency/schemas/createEfficiencyDaySchema.ts
+++ b/src/application/controllers/efficiency/schemas/createEfficiencyDaySchema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const createEfficiencyDaySchema = z.object({
+  rigId: z.string().uuid({ message: "rigId deve ser um UUID válido" }),
+  localDate: z
+    .string()
+    .regex(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/u, {
+      message: "localDate deve estar no formato YYYY-MM-DD",
+    }),
+  status: z.enum(["draft", "ready", "confirmed"]).optional(),
+  totals: z.record(z.string(), z.unknown()).nullable().optional(),
+  confirmedAt: z
+    .union([z.coerce.date(), z.null()])
+    .optional(),
+  confirmedByUserId: z
+    .string()
+    .uuid({ message: "confirmedByUserId deve ser UUID" })
+    .nullable()
+    .optional(),
+});
+
+export type CreateEfficiencyDayBody = z.infer<typeof createEfficiencyDaySchema>;

--- a/src/application/entities/EfficiencyDay.ts
+++ b/src/application/entities/EfficiencyDay.ts
@@ -1,0 +1,47 @@
+export class EfficiencyDay {
+  readonly id?: string;
+  readonly rigId: string;
+  readonly localDate: string;
+  readonly status: EfficiencyDay.Status;
+  readonly totals: EfficiencyDay.Totals | null;
+  readonly confirmedAt?: Date | null;
+  readonly confirmedByUserId?: string | null;
+  readonly createdAt?: Date;
+  readonly updatedAt?: Date;
+
+  constructor(attributes: EfficiencyDay.Attributes) {
+    this.id = attributes.id;
+    this.rigId = attributes.rigId;
+    this.localDate = attributes.localDate;
+    this.status = attributes.status;
+    this.totals = attributes.totals ?? null;
+    this.confirmedAt =
+      attributes.confirmedAt === undefined
+        ? undefined
+        : attributes.confirmedAt ?? null;
+    this.confirmedByUserId =
+      attributes.confirmedByUserId === undefined
+        ? undefined
+        : attributes.confirmedByUserId ?? null;
+    this.createdAt = attributes.createdAt;
+    this.updatedAt = attributes.updatedAt;
+  }
+}
+
+export namespace EfficiencyDay {
+  export type Status = "draft" | "ready" | "confirmed";
+
+  export type Totals = Record<string, unknown>;
+
+  export type Attributes = {
+    id?: string;
+    rigId: string;
+    localDate: string;
+    status: Status;
+    totals?: Totals | null;
+    confirmedAt?: Date | null;
+    confirmedByUserId?: string | null;
+    createdAt?: Date;
+    updatedAt?: Date;
+  };
+}

--- a/src/application/useCases/efficiency/CreateEfficiencyDayUseCase.ts
+++ b/src/application/useCases/efficiency/CreateEfficiencyDayUseCase.ts
@@ -1,0 +1,40 @@
+import { EfficiencyDay } from "@application/entities/EfficiencyDay";
+import { EfficiencyDayRepository } from "@infra/database/neon/repositories/EfficiencyDayRepository";
+import { Injectable } from "@kernel/decorators/Injectable";
+
+@Injectable()
+export class CreateEfficiencyDayUseCase {
+  constructor(
+    private readonly efficiencyDayRepository: EfficiencyDayRepository
+  ) {}
+
+  async execute(
+    input: CreateEfficiencyDayUseCase.Input
+  ): Promise<CreateEfficiencyDayUseCase.Output> {
+    const day = new EfficiencyDay({
+      rigId: input.rigId,
+      localDate: input.localDate,
+      status: input.status ?? "draft",
+      totals: input.totals ?? null,
+      confirmedAt: input.confirmedAt,
+      confirmedByUserId: input.confirmedByUserId,
+    });
+
+    const upsertedDay = await this.efficiencyDayRepository.upsert(day);
+
+    return upsertedDay;
+  }
+}
+
+export namespace CreateEfficiencyDayUseCase {
+  export type Input = {
+    rigId: string;
+    localDate: string;
+    status?: EfficiencyDay.Status;
+    totals?: EfficiencyDay.Totals | null;
+    confirmedAt?: Date | null;
+    confirmedByUserId?: string | null;
+  };
+
+  export type Output = EfficiencyDay;
+}

--- a/src/infra/database/neon/items/EfficiencyDayItem.ts
+++ b/src/infra/database/neon/items/EfficiencyDayItem.ts
@@ -1,0 +1,36 @@
+import { EfficiencyDay } from "@application/entities/EfficiencyDay";
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { efficiencyDays } from "../schema";
+
+export type EfficiencyDayRow = InferSelectModel<typeof efficiencyDays>;
+export type NewEfficiencyDayRow = InferInsertModel<typeof efficiencyDays>;
+
+export class EfficiencyDayItem {
+  static fromRow(row: EfficiencyDayRow): EfficiencyDay {
+    return new EfficiencyDay({
+      id: row.id,
+      rigId: row.rigId,
+      localDate: row.localDate,
+      status: row.status,
+      totals: (row.totals as EfficiencyDay.Totals | null) ?? null,
+      confirmedAt: row.confirmedAt ? new Date(row.confirmedAt) : null,
+      confirmedByUserId: row.confirmedByUserId ?? null,
+      createdAt: row.createdAt ? new Date(row.createdAt) : undefined,
+      updatedAt: row.updatedAt ? new Date(row.updatedAt) : undefined,
+    });
+  }
+
+  static toRow(entity: EfficiencyDay): NewEfficiencyDayRow {
+    return {
+      id: entity.id,
+      rigId: entity.rigId,
+      localDate: entity.localDate,
+      status: entity.status,
+      totals: entity.totals ?? null,
+      confirmedAt: entity.confirmedAt ?? null,
+      confirmedByUserId: entity.confirmedByUserId ?? null,
+      createdAt: entity.createdAt ?? undefined,
+      updatedAt: entity.updatedAt ?? undefined,
+    };
+  }
+}

--- a/src/infra/database/neon/repositories/EfficiencyDayRepository.ts
+++ b/src/infra/database/neon/repositories/EfficiencyDayRepository.ts
@@ -1,0 +1,45 @@
+import { EfficiencyDay } from "@application/entities/EfficiencyDay";
+import { Injectable } from "@kernel/decorators/Injectable";
+import { DatabaseService } from "..";
+import { efficiencyDays } from "../schema";
+import { EfficiencyDayItem } from "../items/EfficiencyDayItem";
+
+@Injectable()
+export class EfficiencyDayRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async upsert(day: EfficiencyDay): Promise<EfficiencyDay> {
+    const row = EfficiencyDayItem.toRow(day);
+
+    const upsertedRow = await this.databaseService.transaction(async (tx) => {
+      const [result] = await tx
+        .insert(efficiencyDays)
+        .values({
+          id: row.id ?? undefined,
+          rigId: row.rigId,
+          localDate: row.localDate,
+          status: row.status,
+          totals: row.totals ?? null,
+          confirmedAt: row.confirmedAt ?? null,
+          confirmedByUserId: row.confirmedByUserId ?? null,
+          createdAt: row.createdAt ?? undefined,
+          updatedAt: row.updatedAt ?? undefined,
+        })
+        .onConflictDoUpdate({
+          target: [efficiencyDays.rigId, efficiencyDays.localDate],
+          set: {
+            status: row.status,
+            totals: row.totals ?? null,
+            confirmedAt: row.confirmedAt ?? null,
+            confirmedByUserId: row.confirmedByUserId ?? null,
+            updatedAt: new Date(),
+          },
+        })
+        .returning();
+
+      return result;
+    });
+
+    return EfficiencyDayItem.fromRow(upsertedRow);
+  }
+}

--- a/src/main/functions/efficiency/createEfficiencyDay.ts
+++ b/src/main/functions/efficiency/createEfficiencyDay.ts
@@ -1,0 +1,5 @@
+import "reflect-metadata";
+import { lambdaHttpAdapter } from "@main/adapters/lambdaHttpAdapter";
+import { CreateEfficiencyDayController } from "@application/controllers/efficiency/CreateEfficiencyDayController";
+
+export const handler = lambdaHttpAdapter(CreateEfficiencyDayController);


### PR DESCRIPTION
## Summary
- replace the Neon HTTP driver with the serverless Pool so Drizzle transactions are available and expose a helper on DatabaseService
- model efficiency day domain mapping plus a repository that performs transactional upserts
- add the createEfficiencyDay HTTP handler, validation schema, and serverless wiring for the new endpoint

## Testing
- pnpm typecheck
- pnpm tsx scripts/tmp/test-create-efficiency-day.ts

------
https://chatgpt.com/codex/tasks/task_e_68e1a089a4c883279e64ea7b255259d7